### PR TITLE
Add pako as dep to fix `process: zlib` in browser

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1305,6 +1305,38 @@ limitations under the License.
 ================================================================================
 
 ================================================================================
+                                      pako
+
+License name: MIT
+  License URL: https://raw.githubusercontent.com/nodeca/pako/master/LICENSE
+  License applies to files under the folder lib/_npm/pako/
+
+Source: https://github.com/nodeca/pako
+================================================================================
+(The MIT License)
+
+Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+================================================================================
+
+================================================================================
                               require-from-string
 
 License name: MIT

--- a/docs/wiki/3rd-party-libraries.md
+++ b/docs/wiki/3rd-party-libraries.md
@@ -84,6 +84,11 @@ Source: https://github.com/localForage/localForage
 
 License: Apache-2.0 (https://raw.githubusercontent.com/localForage/localForage/master/LICENSE)
 
+## pako
+Source: https://github.com/nodeca/pako
+
+License: MIT (https://raw.githubusercontent.com/nodeca/pako/master/LICENSE)
+
 ## require-from-string
 Source: https://github.com/floatdrop/require-from-string
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "kaitai-struct": "next",
     "kaitai-struct-compiler": "^0.8.0-SNAPSHOT.20170906.215006",
     "localforage": "^1.5.0",
+    "pako": "^1.0.4",
     "require-from-string": "^1.2.1",
     "requirejs": "^2.3.5",
     "smooth-scrollbar": "^7.4.1",

--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -102,6 +102,9 @@ function exportValue(obj: any, debug: IDebugInfo, path: string[], noLazy?: boole
 importScripts("../entities.js");
 importScripts("../../lib/_npm/kaitai-struct/KaitaiStream.js");
 
+(KaitaiStream as any).depUrls = (KaitaiStream as any).depUrls  || {};
+(KaitaiStream as any).depUrls.zlib = "../../lib/_npm/pako/pako_inflate.min.js";
+
 var apiMethods = {
     initCode: (sourceCode: string, mainClassName: string, ksyTypes: IKsyTypes) => {
         wi.ksyTypes = ksyTypes;

--- a/vendor.yaml
+++ b/vendor.yaml
@@ -104,7 +104,14 @@ libs:
     licenseUrl: https://raw.githubusercontent.com/localForage/localForage/master/LICENSE
     npmDir: localforage
     files: [LICENSE, dist/localforage.js]
-    
+
+  pako:
+    source: https://github.com/nodeca/pako
+    licenseName: MIT
+    licenseUrl: https://raw.githubusercontent.com/nodeca/pako/master/LICENSE
+    npmDir: pako
+    files: [LICENSE, dist/pako_inflate.min.js]
+
   require.js:
     source: https://github.com/requirejs/requirejs
     licenseName: jQuery license


### PR DESCRIPTION
The javascript runtime provides processZlib for decompressing fields, but relies on node's zlib module to do the job, so this feature didn't work in the WebIDE.

Together with https://github.com/kaitai-io/kaitai_struct_javascript_runtime/pull/4 this fixes things.

The worker now configures a remote dependency url for the runtime, which
loads and uses `pako` to do the zlib decompression in the browser.

Maybe deals with #33?