### PR TITLE
Point docs to kaitai-io/kaitai_struct_webide instead of koczkatamas/....

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,12 +174,12 @@
                 </div>
                 <div class="form-group">
                     You can view the source code or create issues on Github 
-                    for the <a href="https://github.com/koczkatamas/kaitai_struct_webide" target="_blank">WebIDE</a> or
+                    for the <a href="https://github.com/kaitai-io/kaitai_struct_webide" target="_blank">WebIDE</a> or
                     <a href="https://github.com/kaitai-io/kaitai_struct" target="_blank">Kaitai Struct</a>.
                 </div>
                 <div class="form-group">
                     Kaitai WebIDE was made possible by using 
-                    <a href="https://github.com/koczkatamas/kaitai_struct_webide/blob/master/docs/wiki/3rd-party-libraries.md" target="_blank">open-source libraries listed here</a>
+                    <a href="https://github.com/kaitai-io/kaitai_struct_webide/blob/master/docs/wiki/3rd-party-libraries.md" target="_blank">open-source libraries listed here</a>
                     (<a href="LICENSE-3RD-PARTY.txt" target="_blank">licensing information</a>).
                 </div>
                 <div class="form-group">
@@ -193,7 +193,7 @@
                     <div>
                         Kaitai WebIDE version: <span id="webIdeVersion"></span>-SNAPSHOT-<a id="webideCommitId" href=""></a>
                         (<span id="webideCommitDate"></span>,
-                            <a href="https://raw.githubusercontent.com/koczkatamas/kaitai_struct_webide/master/LICENSE" target="_blank">license</a>)
+                            <a href="https://raw.githubusercontent.com/kaitai-io/kaitai_struct_webide/master/LICENSE" target="_blank">license</a>)
                     </div>
                     <div>Kaitai compiler version: <span id="compilerVersion"></span></div>
                 </div>

--- a/src/ui/Parts/AboutModal.html
+++ b/src/ui/Parts/AboutModal.html
@@ -25,12 +25,12 @@
                     </div>
                     <div class="form-group">
                         You can view the source code or create issues on Github 
-                        for the <a href="https://github.com/koczkatamas/kaitai_struct_webide" target="_blank">WebIDE</a> or
+                        for the <a href="https://github.com/kaitai-io/kaitai_struct_webide" target="_blank">WebIDE</a> or
                         <a href="https://github.com/kaitai-io/kaitai_struct" target="_blank">Kaitai Struct</a>.
                     </div>
                     <div class="form-group">
                         Kaitai WebIDE was made possible by using 
-                        <a href="https://github.com/koczkatamas/kaitai_struct_webide/blob/master/docs/wiki/3rd-party-libraries.md" target="_blank">open-source libraries listed here</a>
+                        <a href="https://github.com/kaitai-io/kaitai_struct_webide/blob/master/docs/wiki/3rd-party-libraries.md" target="_blank">open-source libraries listed here</a>
                         (<a href="LICENSE-3RD-PARTY.txt" target="_blank">licensing information</a>).
                     </div>
                     <div class="form-group">
@@ -43,7 +43,7 @@
                     <div class="licenses">
                         <div>
                             Kaitai WebIDE version: {{webideVersion}}-SNAPSHOT-<a :href="webideCommitUrl" target="_blank">{{webideCommitId}}</a>
-                            ({{webideCommitDate}}, <a href="https://raw.githubusercontent.com/koczkatamas/kaitai_struct_webide/master/LICENSE" target="_blank">license</a>)
+                            ({{webideCommitDate}}, <a href="https://raw.githubusercontent.com/kaitai-io/kaitai_struct_webide/master/LICENSE" target="_blank">license</a>)
                         </div>
                         <div>Kaitai compiler version: {{compilerVersion}} ({{compilerBuildDate}})</div>
                     </div>


### PR DESCRIPTION
It seems that the kaitai-io repo is more up to date than the koczkatamas counter part.