### PR TITLE
Prevent value instances from breaking highlighting

### DIFF
--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -277,7 +277,7 @@ export class ParsedTreeHandler {
 
                         var start = exp.ioOffset + exp.start;
                         var end = exp.ioOffset + exp.end - 1;
-                        if (start <= lastEnd || start > end) continue;
+                        if (Number.isNaN(start) || Number.isNaN(end) || start <= lastEnd || start > end) continue;
                         lastEnd = end;
 
                         intervals.push(<IParsedTreeInterval>{ start: start, end: end, exp: exp });


### PR DESCRIPTION
I noticed that the interval highlighting often breaks. I'm sure you've also encountered this issue: invoking a value instance makes the whole rest of the hex dump blank (without colored interval highlighting) or sometimes even the whole file.

A simple repro:

```yaml
meta:
  id: broken_interval_highlighting
seq:
  - id: highlighted
    size: 4
  - id: spoiler
    type: using_val_inst
  - id: not_highlighted
    size: 4
types:
  using_val_inst:
    seq:
      - id: highlighted_nested
        size: 4
    instances:
      agent:
        value: 1
```

The problem arises when building intervals which the individual fields occupy. This code is not aware of value instances and therefore the resulting interval of such looks like this:

```javascript
{
  start: NaN,
  end: NaN,
  exp: {
    start: undefined,
    end: undefined,
    ioOffset: undefined,
    path: (2) ["spoiler", "agent"],
    type: "Primitive",
    primitiveValue: 1
  }
}
```

`NaN`s are in JavaScript very nasty values. In short, using any comparison operator with one of the operand `NaN` will always yield `false` (they're not even equal to themselves, `NaN === NaN` is also `false`). So function `searchRange`, which is used for getting field intervals that are in range from `start` to `end`, will ignore all intervals beyond the first occurence of `NaN` value (it `break`s the loop because [this condition will be always `false` for `NaN`s](https://github.com/kaitai-io/kaitai_struct_webide/blob/de5791e763c61f486dab74ed059b52a2ca2d92ca/src/utils/IntervalHelper.ts#L46).

So I prefer to detect if either `start` or `end` are `NaN`s already when building the intervals, and not push in the array if so.