### PR TITLE
Make serve.js generate kaitaiFsFiles like serve.py did.

### DIFF
--- a/genKaitaiFsFiles.js
+++ b/genKaitaiFsFiles.js
@@ -36,4 +36,8 @@ function main() {
     generate(outDir);
 }
 
-main();
+if (!module.parent) {
+    main();
+}
+
+module.exports = generate;

--- a/serve.js
+++ b/serve.js
@@ -2,6 +2,7 @@ const { readdirSync, statSync } = require("fs");
 const { join } = require("path");
 const express = require("express");
 const ts = require("typescript");
+const genKaitaiFsFiles = require("./genKaitaiFsFiles");
 
 const port = 8000;
 const watchPattern = /(\.html$)|(^js\/)|(^css\/)$/;
@@ -81,6 +82,7 @@ app.get("/onchange", (req, res, next) => {
 app.use(express.static("."));
 
 function main() {
+    genKaitaiFsFiles('');
     if (process.argv.includes("--compile")) {
         startWatcher();
     }


### PR DESCRIPTION
This fixes an issue caused by #95 where kaitaiFsFiles never gets updated/generated in the root, causing the app to not load in serve mode when it is freshly cloned and no kaitaiFsFiles file exists yet. In the original serve.py implementation, it was generated regardless of whether or not the `--compile` flag was passed, so I've taken this route as well.

It should be possible to reproduce this issue by simply cloning and running `node serve.js --compile`.