### PR TITLE
Fix -webide-representation on imported types

### DIFF
--- a/src/v1/KaitaiServices.ts
+++ b/src/v1/KaitaiServices.ts
@@ -72,14 +72,22 @@ export class CompilerService {
     ksySchema: KsySchema.IKsyFile;
     ksyTypes: IKsyTypes;
 
-    compile(srcYamlFsItem: IFsItem, srcYaml: string, kslang: string, debug: true | false | "both"): Promise<any> {
+    async compile(srcYamlFsItem: IFsItem, srcYaml: string, kslang: string, debug: true | false | "both"): Promise<any> {
         var perfYamlParse = performanceHelper.measureAction("YAML parsing");
 
         this.jsImporter.rootFsItem = srcYamlFsItem;
 
         try {
             this.ksySchema = <KsySchema.IKsyFile>YAML.parse(srcYaml);
-            this.ksyTypes = SchemaUtils.collectKsyTypes(this.ksySchema);
+            if (this.ksySchema.meta.imports) {
+                let imports = this.ksySchema.meta.imports.map(item => this.jsImporter.importYaml(item, "rel"))
+                let importedSchemas = await Promise.all(imports)
+                let allSchemes = [...importedSchemas, this.ksySchema]
+                this.ksyTypes = {}
+                Object.assign(this.ksyTypes, ...allSchemes.map(item => SchemaUtils.collectKsyTypes(item)))
+            } else {
+                this.ksyTypes = SchemaUtils.collectKsyTypes(this.ksySchema);
+            }
 
             // we have to modify the schema (add typesByJsName for example) before sending into the compiler so we need a copy
             var compilerSchema = <KsySchema.IKsyFile>YAML.parse(srcYaml);


### PR DESCRIPTION
When type imported, -webide-representation on imported type not worked because ksyTypes are picked up only in the current file.

I know that it is planned to replace this field with a more general method of converting a type to a string at the type level. https://github.com/kaitai-io/kaitai_struct_webide/issues/112 

Perhaps this fix will be useful until *to_string* functionality will be implemented.
