### PR TITLE
Add Dockerfile for WebIDE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine
+
+WORKDIR /app
+
+RUN apk update \
+  && apk add git \
+  && git clone --recursive https://github.com/kaitai-io/kaitai_struct_webide /app \
+  && npm install \
+  && ./build \
+  && npm install -g node-static \
+  && apk del --purge git
+
+EXPOSE 8000
+
+CMD static /app/out -p 8000 -a 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Online editor / visualizer for Kaitai Struct .ksy files
 - `node serve.js --compile`
 - Go to [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
 
+## run locally with Docker
+
+- `git clone https://github.com/kaitai-io/kaitai_struct_webide`
+- `docker build -t kaitai_struct_webide .`
+- `docker run -i -d -p 8000:8000 kaitai_struct_webide`
+- Go to [http://localhost:8000/](http://localhost:8000/)
+
 ## screenshots
 
 ![Example screenshot of a .zip file](docs/zip_example.png)


### PR DESCRIPTION
This PR adds Dockerfile for WebIDE. 
Using Docker is one of the most convenient ways to run an app. I believe providing the official Dockerfile helps a lot.