### PR TITLE
Fix an undefined variable dereference

### DIFF
--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -119,7 +119,7 @@ function exportValue(obj: any, debug: IDebugInfo, hasRawAttr: boolean, path: str
             Object.getOwnPropertyNames(obj.constructor.prototype).filter(x => x[0] !== "_" && x !== "constructor") : [];
 
         for (const propName of propNames) {
-            const ksyInstanceData = ksyType && ksyType.instancesByJsName[propName] || {};
+            const ksyInstanceData = ksyType && ksyType.instancesByJsName && ksyType.instancesByJsName[propName] || {};
             const parseMode = ksyInstanceData["-webide-parse-mode"];
             const eagerLoad = parseMode === "eager" || (parseMode !== "lazy" && ksyInstanceData.value);
 


### PR DESCRIPTION
This fixes the following error in the webide when parsing some JPEG files:

```
Parse error: undefined
Call stack: undefined TypeError: ksyType.instancesByJsName is undefined
```

This issue was confirmed by:
 - me
 - two of my friends (every one of us trying a different JPEG file)
 - people in a 2 yers old discussion thread: https://gitter.im/kaitai_struct/Lobby?at=5d6e5bb238499c13a69268b8

Before:

![image](https://user-images.githubusercontent.com/7026881/147510280-8e6e060a-cafc-4cbe-999a-f8d7d4ad628b.png)

After:

![image](https://user-images.githubusercontent.com/7026881/147510297-519f192a-b295-45d8-8b73-f41de764c40a.png)

