### PR TITLE
Disable font ligatures in hex viewer

### DIFF
--- a/css/HexViewer.css
+++ b/css/HexViewer.css
@@ -1,5 +1,5 @@
 ﻿.hexViewer * { box-sizing: content-box }
-.hexViewer { background: white; color: #333; font-family: Courier,monospace; font-size: 12px; overflow-y: scroll; overflow-x: auto }
+.hexViewer { background: white; color: #333; font-family: Courier,monospace; font-size: 12px; font-variant-ligatures: none; overflow-y: scroll; overflow-x: auto }
 .hexViewer .heightbox { height:10000px; background:blue; float:left }
 .hexViewer .contentOuter {position: relative;height:100%; overflow: hidden; min-width:560px; outline: none !important }
 .hexViewer .content { margin-left: 8px; }


### PR DESCRIPTION
With ligatures enabled, certain combinations of characters, like `ff`, may render with a width less than that of any two other characters, even when using a monospace font. This violates the assumptions used to align the hex view and makes lines containing them look ugly, especially when the ligature is inside the address. To fix this, disable ligatures entirely in the hex viewer.

Before:
![before](https://user-images.githubusercontent.com/1082640/158076635-6b7f00e4-5df1-4f69-bc1d-9f3b75b1033d.png)

After:
![after](https://user-images.githubusercontent.com/1082640/158076639-75eb8d26-214f-45e2-94fe-671ff0a9a198.png)