### PR TITLE
Better error messages when importing an unavailable .ksy

### DIFF
--- a/lib/ts-types/localForage.d.ts
+++ b/lib/ts-types/localForage.d.ts
@@ -18,8 +18,8 @@ interface LocalForageOptions {
 }
 
 interface LocalForageDbMethods {
-    getItem<T>(key: string): Promise<T>;
-    getItem<T>(key: string, callback: (err: any, value: T) => void): void;
+    getItem<T>(key: string): Promise<T | null>;
+    getItem<T>(key: string, callback: (err: any, value: T | null) => void): void;
 
     setItem<T>(key: string, value: T): Promise<T>;
     setItem<T>(key: string, value: T, callback: (err: any, value: T) => void): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -705,9 +705,9 @@
       "integrity": "sha512-81oxVi/OY+LrzgrONX7ciD1wtvq24nb2M9iYixRiQG+1hrDrDRqFVWuQzF1fUexh3Sg/ol6eMAz1MOVYFouzUg=="
     },
     "node_modules/kaitai-struct-compiler": {
-      "version": "0.11.0-SNAPSHOT20231104.85023.e581718",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.11.0-SNAPSHOT20231104.85023.e581718.tgz",
-      "integrity": "sha512-1i5jAfwSAxrB6HkItjdZwpOJqkcHEcoQdRhvFp1U3n5kSTtsuX/0yos+5D65GONcZkl3rf21IN4zwkSsjjMrOw=="
+      "version": "0.11.0-SNAPSHOT20231104.124722.3af7a08",
+      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.11.0-SNAPSHOT20231104.124722.3af7a08.tgz",
+      "integrity": "sha512-iZFRd7Md3tK8+WlD3WBmrIIPTEfmVWWMSNgfeiHOjDS8XAXZBvbvjdtkuMcUgJ1AMbZfozvKK4ecDy6x/scaig=="
     },
     "node_modules/lie": {
       "version": "3.1.1",

--- a/src/v1/KaitaiServices.ts
+++ b/src/v1/KaitaiServices.ts
@@ -57,8 +57,15 @@ class JsImporter implements IYamlImporter {
         }
 
         console.log(`import yaml: ${name}, mode: ${mode}, loadFn: ${loadFn}, root:`, this.rootFsItem);
-        let ksyContent = await fss[importedFsType].get(`${loadFn}.ksy`);
-        var ksyModel = <KsySchema.IKsyFile>YAML.parse(<string>ksyContent);
+        const fn = `${loadFn}.ksy`;
+        const sourceAppendix = mode === 'abs' ? 'kaitai.io' : 'local storage';
+        let ksyContent;
+        try {
+            ksyContent = await fss[importedFsType].get(`${loadFn}.ksy`);
+        } catch (e) {
+            throw new Error(`failed to import spec ${fn} from ${sourceAppendix}${e.message ? ': ' + e.message : ''}`);
+        }
+        const ksyModel = <KsySchema.IKsyFile>YAML.parse(<string>ksyContent);
         return ksyModel;
     }
 }

--- a/src/v1/app.layout.ts
+++ b/src/v1/app.layout.ts
@@ -121,7 +121,8 @@ export class UI {
         this.layout.addEditor("genCodeDebugViewer", "javascript", false);
         this.layout.addComponent("hexViewer", () => {
             var hexViewer = new HexViewer("#hexViewer");
-            hexViewer.bytesPerLine = parseInt(localStorage.getItem("HexViewer.bytesPerLine")) || 16;
+            const stored = localStorage.getItem("HexViewer.bytesPerLine");
+            hexViewer.bytesPerLine = (stored !== null && parseInt(stored, 10)) || 16;
             return hexViewer;
         });
         this.layout.addComponent("errorWindow", cont => { cont.getElement().append($("<div />")); });

--- a/src/v1/app.ts
+++ b/src/v1/app.ts
@@ -279,7 +279,8 @@ $(() => {
     app.formatReady = loadCachedFsItem(app.ksyFsItemName, "kaitai", "formats/archive/zip.ksy");
 
     app.inputReady.then(() => {
-        var storedSelection = JSON.parse(localStorage.getItem("selection"));
+        const value = localStorage.getItem("selection");
+        const storedSelection = value !== null ? JSON.parse(value) : null;
         if (storedSelection)
             app.ui.hexViewer.setSelection(storedSelection.start, storedSelection.end);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "alwaysStrict": true,
+//    "strictNullChecks": true,
     "sourceMap": false,
     "target": "es2017",
     "outDir": "js/",


### PR DESCRIPTION
For example, consider the following spec, which attempts to import a non-existent .ksy file from local storage:

```ksy
meta:
  id: imports_non_existent_local
  imports:
    - non_existent
```

Old error:

```
Parse error (TypeError): Cannot read properties of null (reading 'indexOf')
Call stack: TypeError: Cannot read properties of null (reading 'indexOf')
    at Parser.cleanup (https://ide.kaitai.io/lib/_npm/yamljs/yaml.js:1220:15)
    at Parser.parse (https://ide.kaitai.io/lib/_npm/yamljs/yaml.js:754:23)
    at Yaml.parse (https://ide.kaitai.io/lib/_npm/yamljs/yaml.js:1817:25)
    at JsImporter.importYaml (https://ide.kaitai.io/js/v1/KaitaiServices.js:51:33)
```

New error:

```
(main): /meta/imports/0:
	error: failed to import spec non_existent.ksy from local storage: file not found
```

Import failures from the remote location "kaitai.io" are now also handled - consider this spec:

```ksy
meta:
  id: imports_non_existent_remote
  imports:
    - /common/non_existent
```

Old error:

```
Parse error
Call stack: undefined
```

New error:

```
(main): /meta/imports/0:
	error: failed to import spec formats/common/non_existent.ksy from kaitai.io: file not found
```

When the server responds with some other HTTP status code than 404:

```
(main): /meta/imports/0:
	error: failed to import spec formats/common/bcd.ksy from kaitai.io: server responded with HTTP status 500 (Internal Server Error)
```

When you are no longer connected to the internet, but try to import a remote spec that hasn't been cached locally by the browser:

```
(main): /meta/imports/0:
	error: failed to import spec formats/common/bcd.ksy from kaitai.io: cannot reach the server (message: Failed to fetch), check your internet connection
```