### PR TITLE
Fix temporary error when imports are used, support circular imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -768,9 +768,9 @@
       "integrity": "sha512-81oxVi/OY+LrzgrONX7ciD1wtvq24nb2M9iYixRiQG+1hrDrDRqFVWuQzF1fUexh3Sg/ol6eMAz1MOVYFouzUg=="
     },
     "node_modules/kaitai-struct-compiler": {
-      "version": "0.11.0-SNAPSHOT20231104.124722.3af7a08",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.11.0-SNAPSHOT20231104.124722.3af7a08.tgz",
-      "integrity": "sha512-iZFRd7Md3tK8+WlD3WBmrIIPTEfmVWWMSNgfeiHOjDS8XAXZBvbvjdtkuMcUgJ1AMbZfozvKK4ecDy6x/scaig=="
+      "version": "0.11.0-SNAPSHOT20240221.132806.29d37b8",
+      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.11.0-SNAPSHOT20240221.132806.29d37b8.tgz",
+      "integrity": "sha512-MfDkn1rJaEtPHBmUqu8PqinQvsbbso2UOydT/hZ1NAITngKRoQC085pX42YL6YQfViLUQyHTFGPvJIldmqnUEg=="
     },
     "node_modules/lie": {
       "version": "3.1.1",


### PR DESCRIPTION
Fixes https://github.com/kaitai-io/kaitai_struct_webide/issues/59

Fixes https://github.com/kaitai-io/kaitai_struct_webide/issues/159 - this is a particularly notable instance of the bug, since `TypeError: DosDatetime is not a constructor` is an error that initially everyone gets when they open the Web IDE in a fresh browser (this is because `zip.ksy` is selected by default, and it is affected by the bug since it contains an import).

See https://github.com/kaitai-io/kaitai_struct/issues/1074 and https://github.com/kaitai-io/kaitai_struct_compiler/pull/264 - the actual fix was done in the KSC-generated JS code, which was changed to allow interdependent format modules to be loaded (and added to the global context in the case of the Web IDE) in any order. However, this was a backwards-incompatible change, so this set of Web IDE changes just updates our code to work with the new compiler.