### PR TITLE
Display a partial object tree if a parsing error occurred, indicate errors

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -11,6 +11,7 @@
 #parsedDataTree .missing { font-family: Arial; color: #c00000; }
 .alert-color { color: #FFC20A; }
 .fail-color { color: #FF4136; }
+.instance-fail-color { color: #0074D9; }
 #fileDrop { display:none; font-family: Arial; position: fixed; top: 0; left: 0; bottom: 0; right: 0; background: rgba(0,0,0,0.8); z-index: 9999 }
 #fileDrop>div { border:2px dashed white; border-radius:25px; width:500px; margin-left:-250px; height:180px; margin-top:-100px; position:fixed; top:50%; left:50%; color:white; text-align:center; font-size:22px; padding-top:65px }
 #fileTree { font-family:Arial; font-size:12px }

--- a/css/app.css
+++ b/css/app.css
@@ -1,4 +1,4 @@
-﻿/*.lm_content>div { height: 100%; width: 100% }*/
+/*.lm_content>div { height: 100%; width: 100% }*/
 .lm_splitter.lm_horizontal .lm_drag_handle { left:-5px; width:15px }
 .lm_splitter.lm_vertical .lm_drag_handle { top:-5px; height:15px }
 .errorWindow { background: white; font-family: Courier,monospace; font-size: 12px; white-space: pre-wrap; overflow-y: scroll; }
@@ -9,6 +9,8 @@
 #parsedDataTree.jstree-default>.jstree-container-ul>.jstree-node { margin-left: 0 }
 #parsedDataTree.jstree-default .jstree-ocl { background-position-y: -8px; width:18px; }
 #parsedDataTree .missing { font-family: Arial; color: #c00000; }
+.alert-color { color: #FFC20A; }
+.fail-color { color: #FF4136; }
 #fileDrop { display:none; font-family: Arial; position: fixed; top: 0; left: 0; bottom: 0; right: 0; background: rgba(0,0,0,0.8); z-index: 9999 }
 #fileDrop>div { border:2px dashed white; border-radius:25px; width:500px; margin-left:-250px; height:180px; margin-top:-100px; position:fixed; top:50%; left:50%; color:white; text-align:center; font-size:22px; padding-top:65px }
 #fileTree { font-family:Arial; font-size:12px }

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -40,6 +40,7 @@ interface IExportedValue {
     start: number;
     end: number;
     incomplete: boolean;
+    validationError?: Error;
 
     primitiveValue?: any;
     arrayItems?: IExportedValue[];

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -16,6 +16,11 @@ interface IWorkerMessage {
 }
 /* tslint:enable */
 
+interface IWorkerResponse {
+    result: any;
+    error: any;
+}
+
 interface IInstance {
     path: string[];
     offset: number;

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -41,6 +41,7 @@ interface IExportedValue {
     end: number;
     incomplete: boolean;
     validationError?: Error;
+    instanceError?: Error;
 
     primitiveValue?: any;
     arrayItems?: IExportedValue[];

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -1,4 +1,4 @@
-﻿class ObjectType {
+class ObjectType {
     public static Primitive = "Primitive";
     public static Array = "Array";
     public static TypedArray = "TypedArray";
@@ -39,6 +39,7 @@ interface IExportedValue {
     ioOffset: number;
     start: number;
     end: number;
+    incomplete: boolean;
 
     primitiveValue?: any;
     arrayItems?: IExportedValue[];

--- a/src/v1/ExportToJson.ts
+++ b/src/v1/ExportToJson.ts
@@ -1,4 +1,4 @@
-﻿import { workerMethods } from "./app.worker";
+import { workerMethods } from "./app.worker";
 
 export function exportToJson(useHex: boolean = false) {
     var indentLen = 2;
@@ -44,9 +44,16 @@ export function exportToJson(useHex: boolean = false) {
         }
     }
 
-    return workerMethods.reparse(true).then(exportedRoot => {
-        console.log("exported", exportedRoot);
-        expToNative(exportedRoot);
-        return result;
-    });
+    return workerMethods.reparse(true)
+        .then(response => {
+            if (response.error) {
+                throw response.error;
+            }
+            return response.result;
+        })
+        .then(exportedRoot => {
+            console.log("exported", exportedRoot);
+            expToNative(exportedRoot);
+            return result;
+        });
 }

--- a/src/v1/app.ts
+++ b/src/v1/app.ts
@@ -1,4 +1,4 @@
-﻿import * as localforage from "localforage";
+import * as localforage from "localforage";
 import * as Vue from "vue";
 
 import { UI } from "./app.layout";
@@ -118,7 +118,7 @@ class AppController {
             let jsClassName = this.compilerService.ksySchema.meta.id.split("_").map((x: string) => x.ucFirst()).join("");
             await workerMethods.initCode(debugCode, jsClassName, this.compilerService.ksyTypes);
 
-            let exportedRoot = await workerMethods.reparse(this.vm.disableLazyParsing);
+            const { result: exportedRoot, error: parseError } = await workerMethods.reparse(this.vm.disableLazyParsing);
             kaitaiIde.root = exportedRoot;
             //console.log("reparse exportedRoot", exportedRoot);
 
@@ -142,7 +142,7 @@ class AppController {
                 });
             });
 
-            this.errors.handle(null);
+            this.errors.handle(parseError);
         } catch(error) {
             this.errors.handle(error);
         }

--- a/src/v1/app.ts
+++ b/src/v1/app.ts
@@ -126,12 +126,20 @@ class AppController {
 
             this.ui.parsedDataTreeHandler.jstree.on("state_ready.jstree", () => {
                 this.ui.parsedDataTreeHandler.jstree.on("select_node.jstree", (e, selectNodeArgs) => {
-                    var node = <IParsedTreeNode>selectNodeArgs.node;
+                    const node = <IParsedTreeNode>selectNodeArgs.node;
                     //console.log("node", node);
-                    var exp = this.ui.parsedDataTreeHandler.getNodeData(node).exported;
+                    const exp = this.ui.parsedDataTreeHandler.getNodeData(node).exported;
 
                     if (exp && exp.path)
                         $("#parsedPath").text(exp.path.join("/"));
+
+                    if (exp) {
+                        if (exp.instanceError !== undefined) {
+                            app.errors.handle(exp.instanceError);
+                        } else if (exp.validationError !== undefined) {
+                            app.errors.handle(exp.validationError);
+                        }
+                    }
 
                     if (!this.blockRecursive && exp && exp.start < exp.end) {
                         this.selectedInTree = true;

--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -18,6 +18,7 @@ interface IDebugInfo {
     start: number;
     end: number;
     ioOffset: number;
+    validationError?: Error;
     incomplete: boolean;
     arr?: IDebugInfo[];
     enumName?: string;
@@ -42,6 +43,7 @@ function exportValue(obj: any, debug: IDebugInfo, hasRawAttr: boolean, path: str
         start: debug && debug.start,
         end: debug && debug.end,
         incomplete: debug && debug.incomplete,
+        validationError: (debug && debug.validationError) || undefined,
         ioOffset: debug && debug.ioOffset,
         path: path,
         type: getObjectType(obj)

--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -90,9 +90,15 @@ function exportValue(obj: any, debug: IDebugInfo, path: string[], noLazy?: boole
         }
 
         result.object = { class: obj.constructor.name, instances: {}, fields: {} };
-        var ksyType = wi.ksyTypes[result.object.class];
+        const ksyType = wi.ksyTypes[result.object.class];
 
-        Object.keys(obj).filter(x => x[0] !== "_").forEach(key => result.object.fields[key] = exportValue(obj[key], obj._debug && obj._debug[key], path.concat(key), noLazy));
+        const fieldNames = new Set<string>(Object.keys(obj));
+        if (obj._debug) {
+            Object.keys(obj._debug).forEach(k => fieldNames.add(k));
+        }
+        const fieldNamesArr = Array.from(fieldNames).filter(x => x[0] !== "_");
+        fieldNamesArr
+            .forEach(key => result.object.fields[key] = exportValue(obj[key], obj._debug && obj._debug[key], path.concat(key), noLazy));
 
         const propNames = obj.constructor !== Object ?
             Object.getOwnPropertyNames(obj.constructor.prototype).filter(x => x[0] !== "_" && x !== "constructor") : [];

--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -84,14 +84,6 @@ function exportValue(obj: any, debug: IDebugInfo, path: string[], noLazy?: boole
         result.arrayItems = (<any[]>obj).map((item, i) => exportValue(item, debug && debug.arr && debug.arr[i], path.concat(i.toString()), noLazy));
     }
     else if (result.type === ObjectType.Object) {
-        var childIoOffset = obj._io ? obj._io._byteOffset : 0;
-
-        if (result.start === childIoOffset) { // new KaitaiStream was used, fix start position
-            result.ioOffset = childIoOffset;
-            result.start -= childIoOffset;
-            result.end -= childIoOffset;
-        }
-
         result.object = { class: obj.constructor.name, instances: {}, fields: {} };
         const ksyType = wi.ksyTypes[result.object.class];
 
@@ -154,7 +146,7 @@ var apiMethods = {
         }
         if (hooks.nodeFilter)
             wi.root = hooks.nodeFilter(wi.root);
-        wi.exported = exportValue(wi.root, <IDebugInfo>{ start: 0, end: wi.inputBuffer.byteLength, incomplete: error !== undefined }, [], eagerMode);
+        wi.exported = exportValue(wi.root, { start: 0, end: wi.inputBuffer.byteLength, ioOffset: 0, incomplete: error !== undefined }, [], eagerMode);
         //console.log("parse before return", performance.now() - start, "date", Date.now());
         return {
             result: wi.exported,

--- a/src/v1/kaitaiWorker.ts
+++ b/src/v1/kaitaiWorker.ts
@@ -117,7 +117,7 @@ function exportValue(obj: any, debug: IDebugInfo, hasRawAttr: boolean, path: str
             const parseMode = ksyInstanceData["-webide-parse-mode"];
             const eagerLoad = parseMode === "eager" || (parseMode !== "lazy" && ksyInstanceData.value);
 
-            if (eagerLoad || noLazy) {
+            if (Object.prototype.hasOwnProperty.call(obj, `_m_${propName}`) || eagerLoad || noLazy) {
                 const instHasRawAttr = Object.prototype.hasOwnProperty.call(obj, `_raw__m_${propName}`);
                 result.object.fields[propName] = exportValue(obj[propName], obj._debug["_m_" + propName], instHasRawAttr, path.concat(propName), noLazy);
             } else

--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -222,16 +222,32 @@ export class ParsedTreeHandler {
         else
             text = (showProp ? s`<span class="propName">${propName}</span> = ` : "") + this.primitiveToText(item);
 
-        if (item.incomplete) {
+        if (item.incomplete || item.validationError !== undefined) {
+            const validationError = item.validationError !== undefined ?
+                `${item.validationError.name}: ${item.validationError.message}` :
+                undefined;
+
             const showAsError =
+                validationError !== undefined ||
                 item.type === ObjectType.Undefined ||
                 (item.type === ObjectType.Object && Object.keys(item.object.fields).length === 0);
 
-            if (showAsError) {
-                text += ` <i class="glyphicon glyphicon-exclamation-sign fail-color" title="parsing of this field failed"></i>`;
+            const icon = document.createElement('i');
+            icon.classList.add('glyphicon');
+            icon.classList.add(showAsError ? 'fail-color' : 'alert-color');
+
+            if (validationError !== undefined) {
+                icon.classList.add('glyphicon-remove');
+                icon.title = `validation of this field failed with "${validationError}"`;
+            } else if (showAsError) {
+                icon.classList.add('glyphicon-exclamation-sign');
+                icon.title = `parsing of this field failed`;
             } else {
-                text += ` <i class="glyphicon glyphicon-alert alert-color" title="parsing was interrupted by an error, data may be incomplete"></i>`;
+                icon.classList.add('glyphicon-alert');
+                icon.title = `parsing was interrupted by an error, data may be incomplete`;
             }
+
+            text += ` ${icon.outerHTML}`;
         }
 
         return <IParsedTreeNode>{ text: text, children: isObject || isArray, data: this.addNodeData({ exported: item }) };

--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -222,9 +222,12 @@ export class ParsedTreeHandler {
         else
             text = (showProp ? s`<span class="propName">${propName}</span> = ` : "") + this.primitiveToText(item);
 
-        if (item.incomplete || item.validationError !== undefined) {
+        if (item.incomplete || item.validationError !== undefined || item.instanceError !== undefined) {
             const validationError = item.validationError !== undefined ?
                 `${item.validationError.name}: ${item.validationError.message}` :
+                undefined;
+            const instanceError = item.instanceError !== undefined ?
+                `${item.instanceError.name}: ${item.instanceError.message}` :
                 undefined;
 
             const showAsError =
@@ -234,17 +237,29 @@ export class ParsedTreeHandler {
 
             const icon = document.createElement('i');
             icon.classList.add('glyphicon');
-            icon.classList.add(showAsError ? 'fail-color' : 'alert-color');
+            if (instanceError !== undefined) {
+                icon.classList.add('instance-fail-color');
+            } else {
+                icon.classList.add(showAsError ? 'fail-color' : 'alert-color');
+            }
 
-            if (validationError !== undefined) {
+            if (validationError !== undefined && (instanceError === undefined || item.instanceError === item.validationError)) {
                 icon.classList.add('glyphicon-remove');
-                icon.title = `validation of this field failed with "${validationError}"`;
+                const action = instanceError !== undefined ?
+                    "validation of this instance parsed on explicit request" :
+                    "validation of this field";
+                icon.title = `${action} failed with "${validationError}"`;
             } else if (showAsError) {
                 icon.classList.add('glyphicon-exclamation-sign');
-                icon.title = `parsing of this field failed`;
+                if (instanceError !== undefined) {
+                    icon.title = `explicit parsing of this instance failed with "${instanceError}"`;
+                } else {
+                    icon.title = `parsing of this field failed`;
+                }
             } else {
                 icon.classList.add('glyphicon-alert');
-                icon.title = `parsing was interrupted by an error, data may be incomplete`;
+                const instanceAppendix = instanceError !== undefined ? "explicit " : "";
+                icon.title = `${instanceAppendix}parsing was interrupted by an error, data may be incomplete`;
             }
 
             text += ` ${icon.outerHTML}`;

--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -1,4 +1,4 @@
-﻿import { IInterval, IntervalHandler } from "../utils/IntervalHelper";
+import { IInterval, IntervalHandler } from "../utils/IntervalHelper";
 import { s, htmlescape, asciiEncode, hexEncode, uuidEncode, collectAllObjects } from "../utils";
 import { workerMethods } from "./app.worker";
 import { app } from "./app";
@@ -221,6 +221,18 @@ export class ParsedTreeHandler {
         }
         else
             text = (showProp ? s`<span class="propName">${propName}</span> = ` : "") + this.primitiveToText(item);
+
+        if (item.incomplete) {
+            const showAsError =
+                item.type === ObjectType.Undefined ||
+                (item.type === ObjectType.Object && Object.keys(item.object.fields).length === 0);
+
+            if (showAsError) {
+                text += ` <i class="glyphicon glyphicon-exclamation-sign fail-color" title="parsing of this field failed"></i>`;
+            } else {
+                text += ` <i class="glyphicon glyphicon-alert alert-color" title="parsing was interrupted by an error, data may be incomplete"></i>`;
+            }
+        }
 
         return <IParsedTreeNode>{ text: text, children: isObject || isArray, data: this.addNodeData({ exported: item }) };
     }

--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -297,7 +297,7 @@ export class ParsedTreeHandler {
         var expNode = isRoot ? this.exportedRoot : nodeData.exported;
 
         var isInstance = !expNode;
-        var valuePromise = isInstance ? this.getProp(nodeData.instance.path).then(exp => nodeData.exported = exp) : Promise.resolve(expNode);
+        var valuePromise = isInstance ? this.getProp(nodeData.instance.path).then(({ result: exp }) => nodeData.exported = exp) : Promise.resolve(expNode);
         return valuePromise.then(valueExp => {
             if (isRoot || isInstance) {
                 this.fillKsyTypes(valueExp);


### PR DESCRIPTION
Resolves https://github.com/kaitai-io/kaitai_struct_webide/issues/156

I'm pretty excited about this feature - this should make debugging of .ksy specs and dealing with "invalid" files a lot easier!

Check out the screenshots to see what it looks like in action:

![ks-webide-partial-tree-cropped](https://github.com/kaitai-io/kaitai_struct_webide/assets/47499687/4671cb96-eb79-40ef-9186-2374b34ae6e4)

---

![ks-webide-partial-tree-valid](https://github.com/kaitai-io/kaitai_struct_webide/assets/47499687/ac2113b9-ed11-4b61-94a0-eb2b0cebb502)