### PR TITLE
Skip set_text() for virtual array nodes to keep the readability.

### DIFF
--- a/src/v1/parsedToTree.ts
+++ b/src/v1/parsedToTree.ts
@@ -400,7 +400,22 @@ export class ParsedTreeHandler {
             if (!valueExp.parent)
                 fillParents(valueExp, nodeData && nodeData.parent);
 
-            this.jstree.set_text(node, this.childItemToNode(valueExp, true).text);
+            if (
+                valueExp.type === ObjectType.Array
+                && Object.prototype.hasOwnProperty.call(nodeData, "arrayStart")
+                && Object.prototype.hasOwnProperty.call(nodeData, "arrayEnd")
+            ) {
+                // Skip set_text() for virtual array nodes. It's better to keep it like
+                // "tags"
+                //   |- "[0 … 99]"
+                //     |- "0 [TypeName]"
+                // rather than set_text() the virtual array node to the same value as
+                // "tags"
+                //   |- "tags"
+                //     |- "0 [TypeName]"
+            } else {
+                this.jstree.set_text(node, this.childItemToNode(valueExp, true).text);
+            }
 
             var nodes = this.exportedToNodes(valueExp, nodeData, true);
             nodes.forEach(x => x.id = x.id || this.getNodeId(x));


### PR DESCRIPTION
Before:
![image](https://github.com/kaitai-io/kaitai_struct_webide/assets/2352900/4cfab015-13e5-4e5a-b3b6-a92764f1844f)

After:
![image](https://github.com/kaitai-io/kaitai_struct_webide/assets/2352900/58c72a20-092f-4b50-a0ab-0ae4b1c384fd)

I'm curious about what situation the `set_text()` was originally intended to be used for. It seems like the initial text for each node is already good enough. Perhaps this is meant to handle lazy loading scenarios?