### PR TITLE
Add repository_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
   
   # Allow this workflow to be triggered on the master branch by an external system (such as the kaitai_struct repo's workflow)
   repository_dispatch:
+    types: [rebuild]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - stable
+  
+  # Allow this workflow to be triggered on the master branch by an external system (such as the kaitai_struct repo's workflow)
+  repository_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - master
       - stable
-  
-  # Allow this workflow to be triggered on the master branch by an external system (such as the kaitai_struct repo's workflow)
+
+  # Allow this workflow to be run on the `master` branch when a webhook event
+  # called `repository_dispatch` is triggered. This is used from the CI workflow
+  # in https://github.com/kaitai-io/kaitai_struct to rebuild the devel Web IDE
+  # after a new version of KSC is published to npm.
   repository_dispatch:
-    types: [rebuild]
+    types:
+      - rebuild
 
 jobs:
   build:


### PR DESCRIPTION
This allows the workflow to be triggered from another repository. According to [discussions](https://github.com/orgs/community/discussions/24657#discussioncomment-3244894), when triggered, this will be run on the default branch (master).